### PR TITLE
Added flag to enable web console support

### DIFF
--- a/provisioners/ansible/setup-server.yml
+++ b/provisioners/ansible/setup-server.yml
@@ -176,6 +176,7 @@
       satellite_installer_scenario: satellite
       satellite_installer_options:
           - "--foreman-initial-admin-password {{ sat_pass }}"
+          - "--enable-foreman-plugin-remote-execution-cockpit"
       satellite_installer_command: satellite-installer
     when:
       - satellite_status.stdout is defined


### PR DESCRIPTION
- this enables a feature that allows a satellite user to connect to the cockpit web console on client machines through the host page of a manages system