### PR TITLE
Updates to bootstrap.sh, build.sh, and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,147 @@
 # packer-ansible-ec2
+
 Automated image builds for AWS EC2
 
 # Overview
 
-On occasion, it becomes necessary to prebuild custom golden images for utilization with AWS EC2. This project aims to ease the burden of creating these images via automation. [Packer](https://www.packer.io/) and [Ansible](https://github.com/ansible/ansible) are utilized together, with Packer employing the [the EBS AMI builder](https://www.packer.io/plugins/builders/amazon/ebs). This builder constructs a golden AMI by first launching an EC2 instance from an initial source AMI, then provisioning and customizing that running instance via user-provided automation (Ansible in the case of this project), and finally shutting the instance down and creating a golden AMI from the quiesced instance storage. This is all done in the AWS account specified via credentials. The builder will create temporary keypairs, security group rules, etc. that provide temporary access to the instance while the image is being created/customized.
+This project aims to simplify the process of **building golden images on AWS** through **automation**.
+
+[Packer](https://www.packer.io) and [Ansible](https://github.com/ansible/ansible) are used in combination. `Packer` utilizies the [the EBS AMI builder](https://www.packer.io/plugins/builders/amazon/ebs) to construct a golden AMI.
+
+This involves:  
+
+* _Provisoning_ an EC2 instance from an initial source AMI
+* _Configuring_ it through user-provided automation (in this project's case, Ansible)
+* _Imaging_ a golden AMI from the instance storage after powering the instance down
+
+All of this is carried out within the AWS account specified by the user's credentials by supplying the environment variables:
+
+* `export AWS_ACCESS_KEY_ID=AKID.....` 
+* `export AWS_SECRET_ACCESS_KEY=Abcid9.....`
+
+The builder generates temporary keypairs, security group rules, and other resources that offer temporary access to the instance while the image is being created or customized.
 
 Requirements
 ------------
 
-* Linux or MacOS system, with `git` and `python` available
-* AWS account with existing VPC and subnet within the VPC. The VPC subnet needs to be accessible by your local system, so a publicly accessible subnet at the least should be utilized. Temporary keypairs and security group rules will secure the communication stream.
-* Packer from https://www.packer.io/downloads
-* Ansible installed via the package manager of choice for the given OS/distribution or via `python\pip` module install (virtualenv/venv recommended)
-
-Configuration
+* Linux or MacOS system
+* `git` and `python` installed
+* `bash` shell installed to run `provisioner/script/bootstrap.sh`  
+  The bootstrap script using _bashisms_ that are not POSIX friendly).  
+  If someone would like to create a POSIX friendly `bootstrap.sh`, please submit a PR.
+* AWS account
+  * account `AWS access key ID`
+  * account `AWS secret access key`
+  * existing AWS infrastructure
+    * exiting `vpc`
+    * existing **publically accessable** `subnet` within the `vpc`
+    * **NOTE**: If you wish to create the AWS infrastructure as code, then you can use [this project](https://github.com/rclements-redhat/) to build your AWS infrastructure quickly using IaC using Ansible.  
+  * Packer from https://www.packer.io/downloads
+  * Note: Temporary keypairs and security group rules will secure the communication stream
+  
+CONFIGURE
 ------------
-1) Clone this repo to local system
-2) *cd* to the `packer-ansible-ec2` directory and then `git checkout` the build branch of interest e.g. `git checkout satellite-6.11`
-3) Either edit `packer-build.json` directly or copy to new json file and edit new file  
-<tab>modify the following variables:
-* `ami_name`: "Satellite 6.11 {{isotime `2006-01-02-150405`}}" (default AMI name will include time stamp of build launch)
-* `aws_region`: EC2 region where temporary build instance will run, ie `us-east-1`
-* `vpc_id`: VPC ID that exists in the region specified above
-* `subnet_id`: Subnet ID that exists within above VPC
-* `red_hat_activation_key`: Red Hat Activation key that contains valid subscriptions for products being installed e.g. Red Hat Satellite
-* `red_hat_org_id`: Red Hat organization ID for account that owns above activation key
-* `ah_api_token`: [Red Hat Automation Hub API token](https://console.redhat.com/ansible/automation-hub/token)
-* `satellite_manifest_url`: Red Hat product subscription manifest location accessible by the temporary EC2 builder instance (if required by product installation and/or configuration). Generate manifest [here](https://access.redhat.com/management/subscription_allocations) and then move to specified URL location
 
-EBS AMI Build
+1) Clone this repo to local system
+   
+   `git clone https://github.com/heatmiser/packer-ansible-ec2`
+
+2) Change to the packer-ansible-ec2 directory and perform a git checkout to build the branch of interest
+   
+   `cd packer-ansible-ec2 && git checkout satellite-6.12`
+   
+3) Rename the packer-build-template.json to packer-build.json to make a company of the template
+
+    `cp --no-clobber packer-build-template.json packer-build.json`
+
+4) Edit the packer-build.json settings file and replace the settings so that it works for your implementation. See below.
+
+    `vim packer-build.json || vi packer-build.json || nano packer-build.json`
+
+    Modify the following variables:
+
+    * `ami_name`
+ 
+        Default: `Satellite 6.12 {{`\``isotime 2006-01-02-150405`\``}}`  
+
+        Name of the ami once it is completed  
+        
+    * `aws_region`
+
+        Default: `us-east-1`  
+
+        EC2 region where temporary build instance will run  
+
+    * `vpc_id`
+
+        Placeholder: `_YOUR_AWS_VPC_ID_`  
+
+        VPC ID that exists in the region specified above  
+
+    * `subnet_id`
+
+        Placeholder: `_YOUR_AWS_PUBLIC_SUBNET_ID_`  
+
+        **Publically** accessible subnet ID that exists within above VPC  
+
+    * `red_hat_activation_key`
+  
+        Placeholder: `_YOUR_RED_HAT_ACT_KEY_`  
+        
+        Red Hat Activation key that contains valid subscriptions for products being installed e.g. Red Hat Satellite  
+
+
+    * `red_hat_org_id`
+
+        Placeholder: `_YOUR_RED_HAT_ORG_ID_` 
+
+        Red Hat organization ID for account that owns above activation key  
+
+    * `ah_api_token`
+  
+        Instructions here: [Red Hat Automation Hub API token](https://console.redhat.com/ansible/automation-hub/token)
+
+     * `download_program`: Can be either:  
+
+        Default: `curl`
+
+        * `s3` - ensure `satellite_manifest_url` is a valid `s3://` address
+        * `curl` - ensure `satellite_manifest_url` is a valid `http://` or `https://` address
+        * If anything but `s3`, it defaults to `curl`.
+  
+    * `satellite_manifest_url`
+
+        Placeholder: `_HTTP_OR_S3_ADDRESS_`  
+
+        * Red Hat product subscription manifest location accessible by the temporary EC2 builder instance (if required by product installation and/or configuration)  
+        * Generate manifest [here](https://access.redhat.com/management/subscription_allocations) and then move to a publically `http/s` URL or private `s3` location. See `download_program` option above.
+        * More information about the entire manifest process [here](https://www.redhat.com/en/blog/how-create-and-use-red-hat-satellite-manifest)  
+
+With the above steps completed, you may move on to the EBS AMI Build section below.
+
+BUILD: EBS AMI Build
 -------------
-packer build -machine-readable packer-build.json | tee build_artifact-$(date +%Y-%m-%d.%H%M).txt
+Use either method:
+
+**Option 1: Build Script (_recommended_)**
+
+1) Change into the main repo directory
+
+    `cd packer-ansible-ec2`
+
+2) Run the `./build.sh` script. It will do prechecks and use `nohup` to ensure the build continues if you get disconnected. It will also monitor the fork using `tail -f log`
+
+    `./build.sh`
+
+**Option 2: Ad-hoc (if you disconnect the build will interrupt)**
+  
+1) Change into the main repo directory
+   
+    `cd packer-ansible-ec2`
+
+
+2) Run the packer build on the command line.
+  
+    `packer build -machine-readable packer-build.json | tee build_artifact-$(date +%Y-%m-%d.%H%M).txt`
+    
+    You are living dangerously with this option. If you get disconnected, the build will fail. No prechecks with this method either.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+# Define constants for all the colors 
+RED='\e[0;31m'
+GREEN='\e[0;32m'
+YELLOW='\e[0;33m'
+BLUE='\e[0;34m'
+PURPLE='\e[0;35m'
+CYAN='\e[0;36m'
+WHITE='\e[0;37m'
+DARK_GREY='\e[1;30m'
+BLACK='\e[0;30m'
+BRIGHT_WHITE='\e[1;37m'
+
+# Define constants for bold and underline
+BOLD='\e[1m'
+UNDERLINE='\e[4m'
+
+# Define a constant for resetting the color
+RESET='\e[0m'
+
+# our artifact log file
+BUILD_FILE="build_artifact-$(date +%Y-%m-%d.%H%M).txt"
+
+function log()
+{
+ if [[ "${1}" == "error" ]]
+ then
+   PRE="${DARK_GREY}[${RED}*${DARK_GREY}]${RESET}"
+   echo -e "${PRE} ${2}"
+ else
+   PRE="${DARK_GREY}[${GREEN}*${DARK_GREY}]${RESET}"
+   echo -e "${PRE} ${1}"
+ fi
+}
+
+echo -ne "
+${DARK_GREY}
+-------------------------------------------------------------------${BLUE}${BOLD}
+Satellite AMI ${YELLOW}Golden Image ${BLUE}${BOLD}Builder${DARK_GREY}
+
+GitHub: ${RESET}${CYAN}https://github.com/heatmiser/packer-ansible-ec2${DARK_GREY}
+Build log: ${CYAN}${BUILD_FILE}${DARK_GREY}
+-------------------------------------------------------------------
+${RESET}"
+
+# Check AWS creds
+
+if [[ -z "${AWS_ACCESS_KEY_ID}" ]]; then
+  log "error" "AWS_ACCESS_KEY_ID is not defined."
+  log "error" \
+      "Type: ${CYAN}export ${CYAN}AWS_ACCESS_KEY_ID${DARK_GREY}=${CYAN}YOURACCESSKEYHERE${NORMAL}"
+  echo -e "${DARK_GREY}"
+  exit 1
+fi
+
+if [[ -z "${AWS_SECRET_ACCESS_KEY}" ]]; then
+  log "error" "AWS_SECRET_ACCESS_KEY is not defined."
+  log "error" \
+      "Type: ${CYAN}export ${CYAN}AWS_SECRET_ACCESS_KEY${DARK_GREY}=${CYAN}YOURSECRETKEYHERE${NORMAL}"
+  echo -e "${DARK_GREY}"
+  exit 1
+fi
+
+log "Starting packer"
+
+# start packer in background and redirect its output to a file
+setsid --fork \
+  nohup packer \
+  build \
+  -machine-readable \
+  packer-build.json > "${BUILD_FILE}" 2>&1 </dev/null &
+
+# create a symbolic link to the build file for convience
+ln -sf "${BUILD_FILE}" log
+
+log "Created symbolic link ${GREEN}log ${DARK_GREY}-> ${GREEN}${BUILD_FILE}"
+
+log "You may press ${CYAN}CTRL-C${NORMAL} at any time and it will not cancel packer"
+log "If you lose connection or logout, the build will continue."
+log "To watch the log again just type: ${GREEN}tail -f log${RESET}"
+log "To stop packer, type: ${RED}pkill -15 packer${NORMAL}"
+
+# monitor contents of the log file in real-time
+# Ctrl-C out of tail will _NOT_ send SIGINT to packer since it's forked
+# into a different group
+
+
+echo -e "${DARK_GREY}-------------------------------------------------------------------"
+echo -e "${RESET}"
+
+echo -e "Will start watching the output using: ${BLUE}${BOLD}tail -f log${RESET} in 5 seconds"
+
+sleep 5
+tail -f log
+

--- a/packer-build.json
+++ b/packer-build.json
@@ -3,14 +3,15 @@
         "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
         "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
         "ami_name": "Satellite 6.12 {{isotime `2006-01-02-150405`}}",
-        "aws_region": "us-east-2",
+        "aws_region": "us-east-1",
         "ssh_username": "ec2-user",
-        "vpc_id": "EXISTING-VPC-ID",
-        "subnet_id": "EXISTING-SUBNET-ID",
+        "vpc_id": "_YOUR_AWS_VPC_ID_",
+        "subnet_id": "_YOUR_AWS_PUBLIC_SUBNET_ID_",
         "red_hat_activation_key": "AK-Sat",
-        "red_hat_org_id": "12345678",
-        "ah_api_token": "00998877665544332211",
-        "satellite_manifest_url": "http://some.location.dom/manifest.zip"
+        "red_hat_org_id": "_YOUR_RED_HAT_ORG_ID_",
+        "ah_api_token": "_YOUR_RED_HAT_AUTOMATION_HUB_API_TOKEN_",
+        "download_program": "curl",
+        "satellite_manifest_url": "_HTTP_OR_S3_ADDRESS_"
     },
     "builders": [{
         "type": "amazon-ebs",
@@ -28,7 +29,7 @@
         "source_ami_filter": {
             "filters": {
                 "virtualization-type": "hvm",
-                "name": "RHEL-8.7.*_HVM-*-x86_64-2-Hourly2-GP2",
+		"name": "RHEL-8.7.*_HVM-*-x86_64-*",
                 "root-device-type": "ebs"
             },
             "owners": ["309956199498"],
@@ -76,7 +77,10 @@
             "environment_vars": [
                 "LANG=en_US.UTF-8",
                 "LC_ALL=en_US.UTF-8",
+                "AWS_ACCESS_KEY_ID={{user `aws_access_key`}}",
+                "AWS_SECRET_ACCESS_KEY={{user `aws_secret_key`}}",
                 "api_token={{user `ah_api_token`}}",
+                "download_program={{user `download_program`}}",
                 "satellite_manifest={{user `satellite_manifest_url`}}"
               ],
             "script": "./provisioners/scripts/bootstrap.sh"

--- a/provisioners/scripts/bootstrap.sh
+++ b/provisioners/scripts/bootstrap.sh
@@ -1,21 +1,289 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+## BASH OPTIONS #############################################################
+
 set -ex
 
-sed -i "s/AABBccddeeff112233gghh/$api_token/g" ~/.ansible.cfg
-curl -L $satellite_manifest -o /tmp/manifest.zip
+### VARIABLES ###############################################################
 
-sudo yum -y install @development
-sudo yum -y install python39
+## VERSIONS
 
-export PYVENV_PROJDIR="/tmp/ansible_venv"
-mkdir -p $PYVENV_PROJDIR
-python3.9 -m pip install --user --upgrade pip setuptools
-python3.9 -m venv $PYVENV_PROJDIR
-source $PYVENV_PROJDIR/bin/activate
-python3.9 -m pip install --upgrade pip setuptools
-python3.9 -m pip install wheel
-python3.9 -m pip install \
-   ansible-core==2.11.7 \
-   jmespath
-ansible-galaxy collection install -r /tmp/requirements.yml --force
-history -c
+VER_ANSIBLE_CORE="2.11.7"
+VER_PYTHON="3.9"
+
+## TOGGLES
+
+# Should we verify the aws cli zip package using gnupg?
+# 1 for yes, 0 for no
+BOOL_GPG_VERIFY_AWS_CLI=1
+
+## URLS
+
+# https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
+URL_AWS_CLI_PKG="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+
+## COMMANDS
+
+CMD_PKG_MGR="dnf"
+CMD_PYTHON="python${VER_PYTHON}"
+
+## PACKAGES
+
+# dnf
+PKG_DNF_PYTHON="python$(echo ${VER_PYTHON} | tr -d '.')" 
+PKG_DNF_ZIP="zip"
+PKG_DNF_DEV_GROUP="@development"
+PKG_DNF_GPG="gnupg2"
+
+# python
+PKG_PYTHON_ANSIBLE_CORE="ansible-core==${VER_ANSIBLE_CORE}"
+PKG_PYTHON_JMESPATH="jmespath"
+PKG_PYTHON_WHEEL="wheel"
+
+## DIRS/FILES/PATHS
+
+TMP_DIR="/tmp"
+TMP_MANIFEST_PATH="${TMP_DIR}/manifest.zip"
+REQUIREMENTS_GALAXY="${TMP_DIR}/requirements.yml"
+
+export PYVENV_PROJDIR="${TMP_DIR}/ansible_venv"
+
+## CREDENTIALS
+
+# AWS_ACCESS_KEY_ID provided as an environment variable by packer
+# AWS_SECRET_ACCESS_KEY provided as an environment variable by packer
+
+## STRINGS
+
+STR_SED_PLACEHOLDER="AABBccddeeff112233gghh"
+
+### FUNCTIONS ###############################################################
+
+# Install DNF packages
+dnf_install_packages()
+{
+  # no quotes on ${@} for variable expansion
+  # shellcheck disable=SC2068
+  _dnf install $@
+}
+
+# Remove DNF packages
+dnf_remove_packages()
+{
+  # no quotes on ${@} for variable expansion
+  # shellcheck disable=SC2068
+  _dnf remove $@
+}
+
+# DNF package manager function. Takes inputs from dnf_*_packages functions
+_dnf()
+{
+  if [[ -n "${*}" ]];
+  then
+    # no quotes on ${@:2} as need to have variable expansion
+    # shellcheck disable=SC2068
+    sudo "${CMD_PKG_MGR}" -y "${1}" ${@:2}
+  fi
+}
+
+# Install python modules using pip
+# Loop, so that each argument can specify parameters to pip
+pip_install_packages()
+{
+  if [[ -n "${*}" ]];
+   then
+   for pip_pkg in "${@}"
+   do
+     # don't use quotes around ${pip_pkg} so the string is expanded to args
+     # shellcheck disable=SC2086
+     "${CMD_PYTHON}" -m pip install ${pip_pkg} 
+   done
+  fi
+}
+
+# Import aws pgp public signature
+function import_aws_pgp_pub_sig()
+{
+  # AWS PGP public signature to verify aws cli
+  AWS_PGP_PUBLIC_SIGNATURE=$(cat << EOF
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQINBF2Cr7UBEADJZHcgusOJl7ENSyumXh85z0TRV0xJorM2B/JL0kHOyigQluUG
+ZMLhENaG0bYatdrKP+3H91lvK050pXwnO/R7fB/FSTouki4ciIx5OuLlnJZIxSzx
+PqGl0mkxImLNbGWoi6Lto0LYxqHN2iQtzlwTVmq9733zd3XfcXrZ3+LblHAgEt5G
+TfNxEKJ8soPLyWmwDH6HWCnjZ/aIQRBTIQ05uVeEoYxSh6wOai7ss/KveoSNBbYz
+gbdzoqI2Y8cgH2nbfgp3DSasaLZEdCSsIsK1u05CinE7k2qZ7KgKAUIcT/cR/grk
+C6VwsnDU0OUCideXcQ8WeHutqvgZH1JgKDbznoIzeQHJD238GEu+eKhRHcz8/jeG
+94zkcgJOz3KbZGYMiTh277Fvj9zzvZsbMBCedV1BTg3TqgvdX4bdkhf5cH+7NtWO
+lrFj6UwAsGukBTAOxC0l/dnSmZhJ7Z1KmEWilro/gOrjtOxqRQutlIqG22TaqoPG
+fYVN+en3Zwbt97kcgZDwqbuykNt64oZWc4XKCa3mprEGC3IbJTBFqglXmZ7l9ywG
+EEUJYOlb2XrSuPWml39beWdKM8kzr1OjnlOm6+lpTRCBfo0wa9F8YZRhHPAkwKkX
+XDeOGpWRj4ohOx0d2GWkyV5xyN14p2tQOCdOODmz80yUTgRpPVQUtOEhXQARAQAB
+tCFBV1MgQ0xJIFRlYW0gPGF3cy1jbGlAYW1hem9uLmNvbT6JAlQEEwEIAD4WIQT7
+Xbd/1cEYuAURraimMQrMRnJHXAUCXYKvtQIbAwUJB4TOAAULCQgHAgYVCgkICwIE
+FgIDAQIeAQIXgAAKCRCmMQrMRnJHXJIXEAChLUIkg80uPUkGjE3jejvQSA1aWuAM
+yzy6fdpdlRUz6M6nmsUhOExjVIvibEJpzK5mhuSZ4lb0vJ2ZUPgCv4zs2nBd7BGJ
+MxKiWgBReGvTdqZ0SzyYH4PYCJSE732x/Fw9hfnh1dMTXNcrQXzwOmmFNNegG0Ox
+au+VnpcR5Kz3smiTrIwZbRudo1ijhCYPQ7t5CMp9kjC6bObvy1hSIg2xNbMAN/Do
+ikebAl36uA6Y/Uczjj3GxZW4ZWeFirMidKbtqvUz2y0UFszobjiBSqZZHCreC34B
+hw9bFNpuWC/0SrXgohdsc6vK50pDGdV5kM2qo9tMQ/izsAwTh/d/GzZv8H4lV9eO
+tEis+EpR497PaxKKh9tJf0N6Q1YLRHof5xePZtOIlS3gfvsH5hXA3HJ9yIxb8T0H
+QYmVr3aIUes20i6meI3fuV36VFupwfrTKaL7VXnsrK2fq5cRvyJLNzXucg0WAjPF
+RrAGLzY7nP1xeg1a0aeP+pdsqjqlPJom8OCWc1+6DWbg0jsC74WoesAqgBItODMB
+rsal1y/q+bPzpsnWjzHV8+1/EtZmSc8ZUGSJOPkfC7hObnfkl18h+1QtKTjZme4d
+H17gsBJr+opwJw/Zio2LMjQBOqlm3K1A4zFTh7wBC7He6KPQea1p2XAMgtvATtNe
+YLZATHZKTJyiqA==
+=vYOk
+-----END PGP PUBLIC KEY BLOCK-----
+EOF
+)
+  echo -e "${AWS_PGP_PUBLIC_SIGNATURE}" | gpg --import
+}
+
+# first parameter is sig file
+# second parameter is file
+gpg_check_file()
+{
+  dnf_install_packages "${PKG_DNF_GPG}"
+  import_aws_pgp_pub_sig
+  # From [gnupg] man page:
+  #   - 0 if there are no severe errors
+  #   - 1 if at least a signature was bad,
+  #   - x != 0 other non-zero error codes for fatal error
+  #   Ref: https://www.gnupg.org/documentation/manuals/gpgme/Error-Codes.html
+  #
+  #   || = test for nonzero, if so, then branch { }
+  gpg --verify "${1}" "${2}" ||
+  {
+    echo "FATAL: AWS gpg signature verify has failed on awscliv2.zip"
+    exit 1
+  }
+  echo "OK: AWS gpg signature was successfully verified on awscliv2.zip"
+}
+
+# Function to copy from s3.
+#   - Downloads aws cli
+#   - Downloads zip dnf pkg
+#   - Verifies aws cli was signed by aws using pgp signature
+#   - Copies manifest from s3
+#   - Removes zip dnf pkg
+copy_from_s3()
+{
+   AWS_CLI_ZIP_ABS_PATH="${TMP_DIR}/awscliv2.zip"
+
+   # Download the package from AWS
+   curl "${URL_AWS_CLI_PKG}" -o "${AWS_CLI_ZIP_ABS_PATH}"
+
+   # Test gpg/pgp signature
+   if [[ "${BOOL_GPG_VERIFY_AWS_CLI}" -ne 0 ]]
+   then
+     # Download the pgp signature file from aws
+     curl "${URL_AWS_CLI_PKG}.sig" -o "${AWS_CLI_ZIP_ABS_PATH}.sig"
+     # first parameter is sig file
+     # second parameter is file
+     gpg_check_file "${AWS_CLI_ZIP_ABS_PATH}.sig" "${AWS_CLI_ZIP_ABS_PATH}"
+   fi
+   # gpg_check_file function hard exits with exit code 1 if the pgp check fails
+
+   # If we're here, then everything is fine
+   # download zip, unzip the aws cli and install it
+   dnf_install_packages "${PKG_DNF_ZIP}"
+   unzip "${AWS_CLI_ZIP_ABS_PATH}" -d "${TMP_DIR}" | grep "/install"
+   sudo "${TMP_DIR}/aws/install" -i "${TMP_DIR}" -b "${TMP_DIR}/bin"
+
+   # Use s3 cp to copy the file
+   "${TMP_DIR}/bin/aws" s3 cp "${1}" "${2}"
+
+   # Echo details of the file to the packer log
+   sha256sum "${2}"
+   file "${2}"
+   ls -al "${2}"
+   
+   # zip is not needed anymore
+   dnf_remove_packages "${PKG_DNF_ZIP}"
+}
+
+# Function to download the manifest.
+download_manifest()
+{
+ # Perform manifest download based on value supplied to 
+ # [download_program]
+ #
+ # Valid values:
+ #
+ # - "s3"   | Use amazon [s3] cli to download an asset in [s3]
+ # - "curl" | Use [curl] to download an asset over http/s
+ # - ""     | default will use [curl]
+ #
+ # shellcheck disable=SC2154
+ case "${download_program}" in
+  "s3")
+   copy_from_s3 "${satellite_manifest}" "${TMP_MANIFEST_PATH}"
+   ;;
+   # for option "curl" and if not defined
+    *)
+   curl -L "${satellite_manifest}" -o "${TMP_MANIFEST_PATH}"  
+ esac
+}
+
+# Setup the python venv
+setup_python_venv()
+{
+ # Install pip and create venv
+ "${CMD_PYTHON}" -m pip install --user --upgrade pip setuptools
+ "${CMD_PYTHON}" -m venv "${PYVENV_PROJDIR}"
+ "${CMD_PYTHON}" -m pip install --upgrade pip
+  # load the python venv
+  # shellcheck disable=SC1091
+  source "${PYVENV_PROJDIR}/bin/activate"
+}
+
+# Clean the bash history
+cleanup()
+{
+  # Purge history 
+  history -c
+}
+
+### MAIN ####################################################################
+
+main()
+{
+  # Replace string placeholder with supplied API token
+  echo "Turning logging off to sed RH API token"
+  set +x
+  # shellcheck disable=SC2154
+  sed -i "s/${STR_SED_PLACEHOLDER}/${api_token}/g" ~/.ansible.cfg
+  set -x
+  echo "Logging back on"
+
+  # download the Satellite manifest supplied in the packer-build.json file
+  download_manifest
+
+  # Install python and required packages
+  dnf_install_packages "${PKG_DNF_DEV_GROUP}" "${PKG_DNF_PYTHON}"
+
+  # RC: commented out - venv will create dir if does not exist
+  # mkdir -p "${PYVENV_PROJDIR}"
+
+  # create the python virtual environment
+  setup_python_venv
+
+  # Install wheel, ansible-core, and jmespath python modules
+  pip_install_packages \
+    "${PKG_PYTHON_WHEEL}" \
+    "${PKG_PYTHON_ANSIBLE_CORE}" \
+    "${PKG_PYTHON_JMESPATH}"
+
+  # Install collects from requirements.yml
+  ansible-galaxy collection install -r "${REQUIREMENTS_GALAXY}" --force
+
+  # Remove packages not needed after bootstrap and purge history
+  cleanup
+}
+
+### BOILERPLATE #############################################################
+
+main
+
+### EOF #####################################################################

--- a/provisioners/scripts/venv_wrapper.sh
+++ b/provisioners/scripts/venv_wrapper.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
-source /tmp/ansible_venv/bin/activate && ANSIBLE_FORCE_COLOR=1 PYTHONUNBUFFERED=1 /tmp/ansible_venv/bin/ansible-playbook "$@"
+source /tmp/ansible_venv/bin/activate && \
+  ANSIBLE_FORCE_COLOR=1 PYTHONUNBUFFERED=1 /tmp/ansible_venv/bin/ansible-playbook "$@"


### PR DESCRIPTION
Updates to:

- `bootstrap.sh` to include support for `s3` downloads and other error handling.
- Updates to the README.md for the `satellite-6.12` branch.
- Updates to the `packer-build.json` to include new field "download_program"
- Created new build.sh script to handle disconnects appropriately. File now creates a thread and uses nohup to disconnect the user session from the process. Packer process can be viewed using tail -f
